### PR TITLE
Image google/dart is discontinued

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 default:
-  image: google/dart
+  image: dart
 
 stages:
   - analyze


### PR DESCRIPTION


https://hub.docker.com/r/google/dart/

<!--
    Thank you for contributing!
-->

### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix
[ ] New rule
[ ] Changes an existing rule
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ x] Other, please explain:

<!--
    If this pull request is addressing an issue, please paste a link to the issue here.
-->

<!--
    Please ensure your pull request is ready:

    - Include tests for this change
    - Update documentation for this change
-->

### What changes did you make? (Give an overview)
Adjusted the image so that the discontinued one of google/dart is not used anymore 
See: https://hub.docker.com/r/google/dart/

